### PR TITLE
update(py2): fix nix-shell sha derivations

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "7a590add2fd99cf8f03d0841f7f80e56ed41d809"; # Replace with the desired commit.
-  py2hwsw_sha256 = "jOGyxsRauH9jhGAbD9DgeyzRiRRMqG46QR/wRBuG6ms="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "dace76f2193e23ac7b38be4f783d6c74e458d087"; # Replace with the desired commit.
+  py2hwsw_sha256 = "tKGm5hAsRKjkYKPaXGVydIfnJZM4DqUTff+eDlVaDkA="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 


### PR DESCRIPTION
- this depends on iobundle/py2hwsw#408